### PR TITLE
bugfix: fix coredump issue when future_execute() return network error

### DIFF
--- a/src/client/SessionPool.cpp
+++ b/src/client/SessionPool.cpp
@@ -42,7 +42,7 @@ ExecutionResponse SessionPool::execute(const std::string &stmt) {
   auto result = getIdleSession();
   if (result.second) {
     auto resp = result.first.execute(stmt);
-    if (*resp.spaceName != config_.spaceName_) {
+    if (resp.spaceName != nullptr && *resp.spaceName != config_.spaceName_) {
       // switch to origin space
       result.first.execute("USE " + config_.spaceName_);
     }
@@ -62,7 +62,7 @@ ExecutionResponse SessionPool::executeWithParameter(
   auto result = getIdleSession();
   if (result.second) {
     auto resp = result.first.executeWithParameter(stmt, parameters);
-    if (*resp.spaceName != config_.spaceName_) {
+    if (resp.spaceName != nullptr && *resp.spaceName != config_.spaceName_) {
       // switch to origin space
       result.first.execute("USE " + config_.spaceName_);
     }


### PR DESCRIPTION
bugfix: 修复future_execute()错误时，ExecutionResponse.spaceName == nullptr，直接解引用导致的coredump问题
bugfix: fix coredump issue when future_execute() return network error. In such case, ExecutionResponse.spaceName == nullptr。There is segment fault at SessionPool.cpp@line45 and line65。

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 


#### Description:
segement fault：
![image](https://github.com/vesoft-inc/nebula-cpp/assets/2002208/3205d1e7-41a6-47ea-9bbb-652ec31c0c61)
full log：
[coredump.log](https://github.com/vesoft-inc/nebula-cpp/files/12077305/coredump.log)
source code:
```
ExecutionResponse SessionPool::execute(const std::string &stmt) {
  auto result = getIdleSession();
  if (result.second) {
    auto resp = result.first.execute(stmt);
    if (*resp.spaceName != config_.spaceName_) {    // line45
      // switch to origin space
      result.first.execute("USE " + config_.spaceName_);
    }
    giveBack(std::move(result.first));
    return resp;
  }
...
}
```

根因 / root cause
Connection.cpp @ line145
```
ExecutionResponse Connection::execute(int64_t sessionId, const std::string &stmt) {
  ExecutionResponse resp;
  try {
    resp = client_->future_execute(sessionId, stmt).get();
  } catch (const std::exception &ex) {
    resp = ExecutionResponse{
        ErrorCode::E_RPC_FAILURE, 0, nullptr, nullptr, std::make_unique<std::string>(ex.what())};
  }
  return resp;
}
```


## How do you solve it?
增加 spaceName 非空判断，不无脑解引用
check `ExecutionResponse.spaceName` is nullptr before compared with `config_.spaceName_`

## Special notes for your reviewer, ex. impact of this fix, design document, etc:


