### PR TITLE
add retryConnect() when using session pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ git clone https://github.com/vesoft-inc/nebula-cpp.git
 ### build
 
 ```bash
-bash> cd nebula-clients/cpp && mkdir build && cd build
+bash> cd nebula-cpp && mkdir build && cd build
 bash> cmake ..
 bash> make && sudo make install
 ```

--- a/include/nebula/client/Session.h
+++ b/include/nebula/client/Session.h
@@ -7,6 +7,8 @@
 
 #include <common/datatypes/DataSet.h>
 
+#include <atomic>
+
 #include "nebula/client/Connection.h"
 
 namespace nebula {
@@ -25,14 +27,16 @@ class Session {
           const std::string &username,
           const std::string &password,
           const std::string &timezoneName,
-          int32_t offsetSecs)
+          int32_t offsetSecs,
+          bool retryConnect)
       : sessionId_(sessionId),
         conn_(std::move(conn)),
         pool_(pool),
         username_(username),
         password_(password),
         timezoneName_(timezoneName),
-        offsetSecs_(offsetSecs) {}
+        offsetSecs_(offsetSecs),
+        retryConnect_(retryConnect) {}
   Session(const Session &) = delete;  // no copy
   Session(Session &&session)
       : sessionId_(session.sessionId_),
@@ -41,7 +45,8 @@ class Session {
         username_(std::move(session.username_)),
         password_(std::move(session.password_)),
         timezoneName_(std::move(session.timezoneName_)),
-        offsetSecs_(session.offsetSecs_) {
+        offsetSecs_(session.offsetSecs_),
+        retryConnect_(session.retryConnect_) {
     session.sessionId_ = -1;
     session.pool_ = nullptr;
     session.offsetSecs_ = 0;
@@ -117,6 +122,8 @@ class Session {
   // empty means not a named timezone
   std::string timezoneName_;
   int32_t offsetSecs_;
+  bool retryConnect_{true};
+  std::atomic<bool> connectionIsBroken_{false};
 };
 
 }  // namespace nebula

--- a/src/client/Connection.cpp
+++ b/src/client/Connection.cpp
@@ -296,7 +296,9 @@ void Connection::close() {
 
 bool Connection::ping() {
   auto resp = execute(0 /*Only check connection*/, "YIELD 1");
-  if (resp.errorCode == ErrorCode::E_RPC_FAILURE || resp.errorCode == ErrorCode::E_DISCONNECTED) {
+  if (resp.errorCode == ErrorCode::E_RPC_FAILURE ||
+      resp.errorCode == ErrorCode::E_FAIL_TO_CONNECT ||
+      resp.errorCode == ErrorCode::E_DISCONNECTED) {
     DLOG(ERROR) << "Ping failed: " << *resp.errorMsg;
     return false;
   }

--- a/src/client/Connection.cpp
+++ b/src/client/Connection.cpp
@@ -191,6 +191,12 @@ ExecutionResponse Connection::executeWithParameter(
   ExecutionResponse resp;
   try {
     resp = client_->future_executeWithParameter(sessionId, stmt, parameters).get();
+  } catch (const apache::thrift::transport::TTransportException &ex) {
+    resp = ExecutionResponse{ErrorCode::E_FAIL_TO_CONNECT,
+                             0,
+                             nullptr,
+                             nullptr,
+                             std::make_unique<std::string>(ex.what())};
   } catch (const std::exception &ex) {
     resp = ExecutionResponse{
         ErrorCode::E_RPC_FAILURE, 0, nullptr, nullptr, std::make_unique<std::string>(ex.what())};

--- a/src/client/ConnectionPool.cpp
+++ b/src/client/ConnectionPool.cpp
@@ -43,7 +43,6 @@ void ConnectionPool::close() {
 Session ConnectionPool::getSession(const std::string &username,
                                    const std::string &password,
                                    bool retryConnect) {
-  (void)retryConnect;
   Connection conn = getConnection();
   auto resp = conn.authenticate(username, password);
   if (resp.errorCode != ErrorCode::SUCCEEDED || resp.sessionId == nullptr) {
@@ -55,7 +54,8 @@ Session ConnectionPool::getSession(const std::string &username,
                  username,
                  password,
                  *resp.timeZoneName,
-                 *resp.timeZoneOffsetSeconds);
+                 *resp.timeZoneOffsetSeconds,
+                 retryConnect);
 }
 
 Connection ConnectionPool::getConnection() {

--- a/src/client/SessionPool.cpp
+++ b/src/client/SessionPool.cpp
@@ -39,22 +39,7 @@ bool SessionPool::init() {
 }
 
 ExecutionResponse SessionPool::execute(const std::string &stmt) {
-  auto result = getIdleSession();
-  if (result.second) {
-    auto resp = result.first.execute(stmt);
-    if (resp.spaceName != nullptr && *resp.spaceName != config_.spaceName_) {
-      // switch to origin space
-      result.first.execute("USE " + config_.spaceName_);
-    }
-    giveBack(std::move(result.first));
-    return resp;
-  } else {
-    return ExecutionResponse{ErrorCode::E_DISCONNECTED,
-                             0,
-                             nullptr,
-                             nullptr,
-                             std::make_unique<std::string>("No idle session.")};
-  }
+  return executeWithParameter(stmt, {});
 }
 
 ExecutionResponse SessionPool::executeWithParameter(

--- a/src/client/tests/ConnectionTest.cpp
+++ b/src/client/tests/ConnectionTest.cpp
@@ -12,6 +12,7 @@
 #include <nebula/client/Connection.h>
 
 #include "./ClientTest.h"
+#include "common/graph/Response.h"
 
 // Require a nebula server could access
 
@@ -148,7 +149,9 @@ TEST_F(ConnectionTest, Timeout) {
   // execute
   resp = c.execute(*authResp.sessionId,
                    "use conn_test;GO 100000 STEPS FROM 'Tim Duncan' OVER like YIELD like._dst;");
-  ASSERT_EQ(resp.errorCode, nebula::ErrorCode::E_RPC_FAILURE) << *resp.errorMsg;
+  ASSERT_TRUE(resp.errorCode == nebula::ErrorCode::E_RPC_FAILURE ||
+              resp.errorCode == nebula::ErrorCode::E_FAIL_TO_CONNECT)
+      << *resp.errorMsg;
 
   resp =
       c.execute(*authResp.sessionId,

--- a/src/client/tests/SessionTest.cpp
+++ b/src/client/tests/SessionTest.cpp
@@ -19,6 +19,7 @@
 #include <thread>
 
 #include "./ClientTest.h"
+#include "common/graph/Response.h"
 
 // Require a nebula server could access
 
@@ -211,7 +212,9 @@ TEST_F(SessionTest, Timeout) {
   // execute
   resp = session.execute(
       "use session_test;GO 100000 STEPS FROM 'Tim Duncan' OVER like YIELD like._dst;");
-  ASSERT_EQ(resp.errorCode, nebula::ErrorCode::E_RPC_FAILURE) << *resp.errorMsg;
+  ASSERT_TRUE(resp.errorCode == nebula::ErrorCode::E_FAIL_TO_CONNECT ||
+              resp.errorCode == nebula::ErrorCode::E_RPC_FAILURE)
+      << *resp.errorMsg;
 
   resp = session.execute(
       "SHOW QUERIES "


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: [119](https://github.com/vesoft-inc/nebula-cpp/issues/119)


#### Description:
When using SessionPool to query, there will be some connect error as the connection could be broken, then, using these connection to query will fail.

## How do you solve it?
Add retryConnect() when query failed.
This implementation refers to [the java client](https://github.com/vesoft-inc/nebula-java/blob/b703e03bb062b8fac8989ddc35f2b3243b4d3510/client/src/main/java/com/vesoft/nebula/client/graph/net/Session.java#L116)

## Special notes for your reviewer, ex. impact of this fix, design document, etc:


