### PR TITLE
fix handling with IO error

### DIFF
--- a/include/nebula/client/SessionPool.h
+++ b/include/nebula/client/SessionPool.h
@@ -21,9 +21,9 @@ struct SessionPoolConfig {
   std::string password_;
   std::vector<std::string> addrs_;  // the list of graph addresses
   std::string spaceName_;
-  // Socket timeout and Socket connection timeout, unit: seconds
+  // Socket timeout and Socket connection timeout, unit: milliseconds
   std::uint32_t timeout_{0};
-  // The idleTime of the connection, unit: seconds
+  // The idleTime of the connection, unit: milliseconds
   // If connection's idle time is longer than idleTime, it will be delete
   // 0 value means the connection will not expire
   std::uint32_t idleTime_{0};

--- a/src/client/tests/ConnectionTest.cpp
+++ b/src/client/tests/ConnectionTest.cpp
@@ -149,9 +149,7 @@ TEST_F(ConnectionTest, Timeout) {
   // execute
   resp = c.execute(*authResp.sessionId,
                    "use conn_test;GO 100000 STEPS FROM 'Tim Duncan' OVER like YIELD like._dst;");
-  ASSERT_TRUE(resp.errorCode == nebula::ErrorCode::E_RPC_FAILURE ||
-              resp.errorCode == nebula::ErrorCode::E_FAIL_TO_CONNECT)
-      << *resp.errorMsg;
+  ASSERT_TRUE(resp.errorCode == nebula::ErrorCode::E_SESSION_TIMEOUT) << *resp.errorMsg;
 
   resp =
       c.execute(*authResp.sessionId,

--- a/src/client/tests/SessionTest.cpp
+++ b/src/client/tests/SessionTest.cpp
@@ -212,9 +212,7 @@ TEST_F(SessionTest, Timeout) {
   // execute
   resp = session.execute(
       "use session_test;GO 100000 STEPS FROM 'Tim Duncan' OVER like YIELD like._dst;");
-  ASSERT_TRUE(resp.errorCode == nebula::ErrorCode::E_FAIL_TO_CONNECT ||
-              resp.errorCode == nebula::ErrorCode::E_RPC_FAILURE)
-      << *resp.errorMsg;
+  ASSERT_TRUE(resp.errorCode == nebula::ErrorCode::E_SESSION_TIMEOUT) << *resp.errorMsg;
 
   resp = session.execute(
       "SHOW QUERIES "


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
When the server returns "TTransportException", the client tries to reConnect() before, however, "Timeout" or other error also belong to "TTransportException", and these errors don't need to reConnect();

## How do you solve it?
Only error of "END_OF_FILE" and "Connection reset by peer" try to reConnect()


