### PR TITLE
fix session error

### DIFF
--- a/include/nebula/client/Session.h
+++ b/include/nebula/client/Session.h
@@ -110,6 +110,12 @@ class Session {
     return toLocal(data, offsetSecs_);
   }
 
+  bool isSessionError(const ExecutionResponse &resp) {
+    return resp.errorCode == ErrorCode::E_SESSION_INVALID ||
+           resp.errorCode == ErrorCode::E_SESSION_NOT_FOUND ||
+           resp.errorCode == ErrorCode::E_SESSION_TIMEOUT;
+  }
+
   // convert the time to specific time zone
   static void toLocal(DataSet &data, int32_t offsetSecs);
 

--- a/include/nebula/client/Session.h
+++ b/include/nebula/client/Session.h
@@ -110,7 +110,7 @@ class Session {
     return toLocal(data, offsetSecs_);
   }
 
-  bool isSessionError(const ExecutionResponse &resp) {
+  static bool isSessionError(const ExecutionResponse &resp) {
     return resp.errorCode == ErrorCode::E_SESSION_INVALID ||
            resp.errorCode == ErrorCode::E_SESSION_NOT_FOUND ||
            resp.errorCode == ErrorCode::E_SESSION_TIMEOUT;

--- a/src/client/Session.cpp
+++ b/src/client/Session.cpp
@@ -37,7 +37,7 @@ ExecutionResponse Session::executeWithParameter(
   auto resp = conn_.executeWithParameter(sessionId_, stmt, parameters);
   if (resp.errorCode == nebula::ErrorCode::SUCCEEDED) {
     return resp;
-  } else if (resp.errorCode == nebula::ErrorCode::E_FAIL_TO_CONNECT) {
+  } else if (resp.errorCode == nebula::ErrorCode::E_FAIL_TO_CONNECT || isSessionError(resp)) {
     connectionIsBroken_ = true;
     if (retryConnect_) {
       if (retryConnect() == nebula::ErrorCode::SUCCEEDED) {


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
When using session pool, we have added retryConnect() if connection was broken, but, there is still a problem.
When the session is invalid, the query will fail with the bad session even the user try to query more times, as session can not recover by itself now.


## How do you solve it?
So, when the session is invalid, we can also try to recreate the session, and make sure all the session is valid in the session pool.


