### PR TITLE
fix connection error

### DIFF
--- a/examples/SessionPoolExample.cpp
+++ b/examples/SessionPoolExample.cpp
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <chrono>
 #include <thread>
+
 #include "nebula/client/Config.h"
 
 int main(int argc, char* argv[]) {
@@ -33,12 +34,13 @@ int main(int argc, char* argv[]) {
   config.spaceName_ = "session_pool_test";
   config.maxSize_ = 10;
   nebula::SessionPool pool(config);
-  pool.init();
+  assert(pool.init());
 
   std::vector<std::thread> threads;
   for (std::size_t i = 0; i < config.maxSize_; ++i) {
     threads.emplace_back([&pool]() {
       auto resp = pool.execute("YIELD 1");
+      std::cout << "resp's error code: " << resp.errorCode << std::endl;
       assert(resp.errorCode == nebula::ErrorCode::SUCCEEDED);
       std::cout << "Result: " << *resp.data << std::endl;
     });

--- a/include/nebula/client/Session.h
+++ b/include/nebula/client/Session.h
@@ -112,8 +112,7 @@ class Session {
 
   static bool isSessionError(const ExecutionResponse &resp) {
     return resp.errorCode == ErrorCode::E_SESSION_INVALID ||
-           resp.errorCode == ErrorCode::E_SESSION_NOT_FOUND ||
-           resp.errorCode == ErrorCode::E_SESSION_TIMEOUT;
+           resp.errorCode == ErrorCode::E_SESSION_NOT_FOUND;
   }
 
   // convert the time to specific time zone

--- a/src/client/Connection.cpp
+++ b/src/client/Connection.cpp
@@ -181,7 +181,9 @@ ExecutionResponse Connection::executeWithParameter(
     std::string errMsg = ex.what();
     if (errType == TTransportException::END_OF_FILE ||
         (errType == TTransportException::INTERNAL_ERROR &&
-         errMsg.find("Connection reset by peer") != std::string::npos)) {
+         errMsg.find("Connection reset by peer") != std::string::npos) ||
+        (errType == TTransportException::UNKNOWN &&
+         errMsg.find("Channel is !good()") != std::string::npos)) {
       resp = ExecutionResponse{
           ErrorCode::E_FAIL_TO_CONNECT, 0, nullptr, nullptr, std::make_unique<std::string>(errMsg)};
     } else if (errType == TTransportException::TIMED_OUT) {


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
When the connection was broken, there is still another error "Channel is !good()", see [fbthrift](https://github.com/facebook/fbthrift/blob/0680ba742099da7d6c28ad4fc24e034d858178ec/thrift/lib/cpp2/async/Cpp2Channel.cpp#L233), and this error hasn't added retryConnect().

## How do you solve it?
retryConnect() when this happens



