### PR TITLE
fix MetaClient bug

### DIFF
--- a/include/nebula/mclient/MetaClient.h
+++ b/include/nebula/mclient/MetaClient.h
@@ -11,6 +11,7 @@
 #include <thread>
 #include <unordered_map>
 #include <vector>
+#include <mutex>
 
 #include "common/datatypes/HostAddr.h"
 #include "common/thrift/ThriftTypes.h"
@@ -108,7 +109,10 @@ class MetaClient {
   void getResponse(Request req,
                    RemoteFunc remoteFunc,
                    RespGenerator respGen,
-                   folly::Promise<std::pair<bool, Response>> pro);
+                   folly::Promise<std::pair<bool, Response>> pro,
+                   int32_t retry = 0,
+                   int32_t retry_limit = 3);
+  void updateLeader(HostAddr leader = HostAddr());
 
  private:
   std::vector<HostAddr> metaAddrs_;
@@ -116,6 +120,8 @@ class MetaClient {
   SpaceNameIdMap spaceIndexByName_;
   SpaceEdgeNameTypeMap spaceEdgeIndexByName_;
   SpaceTagNameTypeMap spaceTagIndexByName_;
+  std::mutex hostLock_;
+  HostAddr leader_;
   std::unordered_map<std::pair<GraphSpaceID, PartitionID>, HostAddr, pair_hash> spacePartLeaderMap_;
   std::unordered_map<GraphSpaceID, std::vector<PartitionID>> spacePartsMap_;
   std::shared_ptr<folly::IOThreadPoolExecutor> ioExecutor_;

--- a/src/mclient/MetaClient.cpp
+++ b/src/mclient/MetaClient.cpp
@@ -23,6 +23,7 @@ MetaClient::MetaClient(const std::vector<std::string>& metaAddrs, const MConfig&
     metaAddrs_.emplace_back(ip_port[0], folly::to<int32_t>(ip_port[1]));
   }
   CHECK(!metaAddrs_.empty()) << "metaAddrs_ is empty";
+  leader_ = metaAddrs_.back();
   mConfig_ = mConfig;
   SSLConfig sslcfg;
   sslcfg.enable_mtls = mConfig_.enableMTLS_;

--- a/src/mclient/MetaClient.cpp
+++ b/src/mclient/MetaClient.cpp
@@ -234,7 +234,12 @@ void MetaClient::getResponse(Request req,
                              RespGenerator respGen,
                              folly::Promise<std::pair<bool, Response>> pro) {
   auto* evb = DCHECK_NOTNULL(ioExecutor_)->getEventBase();
-  HostAddr host = metaAddrs_.back();
+  
+  HostAddr host;
+  {
+    std::lock_guard<std::mutex> holder(hostLock_);
+    host = leader_;
+  }
   folly::via(evb,
              [host,
               evb,
@@ -242,28 +247,94 @@ void MetaClient::getResponse(Request req,
               remoteFunc = std::move(remoteFunc),
               respGen = std::move(respGen),
               pro = std::move(pro),
+              retry,
+              retryLimit,
               this]() mutable {
-               auto client = clientsMan_->client(host, evb, false, mConfig_.clientTimeoutInMs_);
-               LOG(INFO) << "Send request to meta " << host;
-               remoteFunc(client, req)
-                   .via(evb)
-                   .then([host, respGen = std::move(respGen), pro = std::move(pro)](
-                             folly::Try<RpcResponse>&& t) mutable {
-                     // exception occurred during RPC
-                     if (t.hasException()) {
-                       LOG(ERROR) << "Send request to meta" << host << " failed";
-                       pro.setValue(std::make_pair(false, Response()));
-                       return;
-                     }
-                     auto&& resp = t.value();
-                     if (resp.get_code() == nebula::cpp2::ErrorCode::SUCCEEDED) {
-                       // succeeded
-                       pro.setValue(respGen(std::move(resp)));
-                       return;
-                     }
-                     pro.setValue(std::make_pair(false, Response()));
-                   });  // then
-             });        // via
+                auto client = clientsMan_->client(host, evb, false, mConfig_.clientTimeoutInMs_);
+                LOG(INFO) << "Send request to meta " << host;
+                remoteFunc(client, req)
+                    .via(evb)
+                    .then([host,
+                          req = std::move(req),
+                          remoteFunc = std::move(remoteFunc),
+                          respGen = std::move(respGen),
+                          pro = std::move(pro),
+                          retry,
+                          retryLimit,
+                          evb,
+                          this](folly::Try<RpcResponse>&& t) mutable {
+                      // exception occurred during RPC
+                        if (t.hasException()) {
+                          updateLeader();
+                          if (retry < retryLimit) {
+                            evb->runAfterDelay(
+                                [req = std::move(req),
+                                remoteFunc = std::move(remoteFunc),
+                                respGen = std::move(respGen),
+                                pro = std::move(pro),
+                                retry,
+                                retryLimit,
+                                this]() mutable {
+                                  getResponse(std::move(req),
+                                              std::move(remoteFunc),
+                                              std::move(respGen),
+                                              std::move(pro),
+                                              retry + 1,
+                                              retryLimit);
+                                },
+                                1000);
+                            return;
+                          } else {
+                            LOG(ERROR) << "Send request to " << host << ", exceed retry limit";
+                            pro.setValue(std::make_pair(false, Response()));
+                          }
+                          return;
+                        }
+
+                        auto&& resp = t.value();
+                        auto code = resp.get_code();
+                        if (code == nebula::cpp2::ErrorCode::SUCCEEDED) {
+                          // succeeded
+                          pro.setValue(respGen(std::move(resp)));
+                          return;
+                        } else if (code == nebula::cpp2::ErrorCode::E_LEADER_CHANGED ||
+                                  code == nebula::cpp2::ErrorCode::E_MACHINE_NOT_FOUND) {
+                          updateLeader(resp.get_leader());
+                          if (retry < retryLimit) {
+                            evb->runAfterDelay(
+                                [req = std::move(req),
+                                remoteFunc = std::move(remoteFunc),
+                                respGen = std::move(respGen),
+                                pro = std::move(pro),
+                                retry,
+                                retryLimit,
+                                this]() mutable {
+                                  getResponse(std::move(req),
+                                              std::move(remoteFunc),
+                                              std::move(respGen),
+                                              std::move(pro),
+                                              retry + 1,
+                                              retryLimit);
+                                },
+                                1000);
+                            return;
+                          }
+                        } else if (code == nebula::cpp2::ErrorCode::E_CLIENT_SERVER_INCOMPATIBLE) {
+                          pro.setValue(respGen(std::move(resp)));
+                          return;
+                        }
+                        pro.setValue(std::make_pair(false, Response()));
+                    });  // then
+              });        // via
+}
+
+void MetaClient::updateLeader(HostAddr leader) {
+  std::lock_guard<std::mutex> holder(hostLock_);
+  if (leader != HostAddr("", 0)) {
+    leader_ = leader;
+  } else {
+    leader_ = addrs_[folly::Random::rand64(addrs_.size())];
+  }
 }
 
 }  // namespace nebula


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 140


#### Description:
When I use nebula-cpp to scan data, it will be failed sometimes. Three metad servers are deployed in the environment.
I noticed that metad client use metaAddrs_.back() to connect to the server. However, metaAddrs_.back() is not necessarily the leader and errors will occurred sometimes.

## How do you solve it?
When the selected metad is not the leader, the leader information will be obtained from the response message and the request will be retried. Meanwhile, the local leader will be updated for the next request.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:


